### PR TITLE
[Add] TestShell Ssd class의 read 기능 구현

### DIFF
--- a/TestShell/TestShell/Ssd.cpp
+++ b/TestShell/TestShell/Ssd.cpp
@@ -1,5 +1,6 @@
 #include <string>
 #include <iostream>
+#include <fstream>
 #include <Windows.h>
 
 #include "Ssd.h"
@@ -23,7 +24,34 @@ string Ssd::convertToWriteCmd(int lba, std::string& data)
 	return result;
 }
 
-int Ssd::read(int lba)
+string Ssd::readResultFile(const std::string& filepath) {
+	string content;
+	std::ifstream file(filepath);
+	if (!file.is_open()) {
+		std::cerr << "Error: Failed to open result.txt file for reading!" << std::endl;
+		return "";
+	}
+
+	std::string line;
+	while (std::getline(file, line)) {
+		content += line + "\n";
+	}
+
+	file.close();
+	return content;
+}
+
+string Ssd::read(int lba)
 {
-	return 0;
+	string readCmd = convertToReadCmd(lba);
+	ShellExecuteA(NULL, "open", "ssd", readCmd.c_str(), SSD_LOCATION.c_str(), SW_HIDE);
+	return readResultFile("../../SSD/result.txt");
+}
+
+string Ssd::convertToReadCmd(int lba)
+{
+	string result = "R ";
+	result += std::to_string(lba);
+	result += " ";
+	return result;
 }

--- a/TestShell/TestShell/Ssd.h
+++ b/TestShell/TestShell/Ssd.h
@@ -4,10 +4,12 @@
 class Ssd : public SsdApi {
 public:
 	void write(int lba, std::string data) override;
-	int read(int lba) override;
+	std::string read(int lba) override;
 
 private:
 	static const std::string SSD_LOCATION;
 
 	std::string convertToWriteCmd(int lba, std::string& data);
+	std::string convertToReadCmd(int lba);
+	std::string readResultFile(const std::string& filepath);
 };

--- a/TestShell/TestShell/SsdApi.h
+++ b/TestShell/TestShell/SsdApi.h
@@ -5,5 +5,5 @@
 
 interface SsdApi {
 	virtual void write(int lba, std::string data) = 0;
-	virtual int read(int lba) = 0;
+	virtual std::string read(int lba) = 0;
 };

--- a/TestShell/TestShell/TestShell.cpp
+++ b/TestShell/TestShell/TestShell.cpp
@@ -98,8 +98,7 @@ void TestShell::verifyWriteDataLength(std::string& strData)
 string TestShell::read(string strLba)
 {
 	int iLba = verifyConvertLba(strLba);
-	ssdApi->read(iLba);
-	string result = readResultFile("../../SSD/result.txt");
+	string result = ssdApi->read(iLba);
 	cout << result << endl;
 	return result;
 }
@@ -107,8 +106,7 @@ string TestShell::read(string strLba)
 void TestShell::fullRead()
 {
 	for (int idx = 0; idx < 100; idx++) {
-		ssdApi->read(idx);
-		cout << readResultFile("../../SSD/result.txt") << endl;
+		cout << ssdApi->read(idx);
 	}
 }
 
@@ -122,23 +120,6 @@ int TestShell::verifyConvertLba(string& strLba) {
 
 	iLba = stoi(strLba);
 	return iLba;
-}
-
-string TestShell::readResultFile(const std::string& filepath) {
-	string content;
-	std::ifstream file(filepath);
-	if (!file.is_open()) {
-		std::cerr << "Error: Failed to open result.txt file for reading!" << std::endl;
-		return "";
-	}
-
-	std::string line;
-	while (std::getline(file, line)) {
-		content += line + "\n";
-	}
-
-	file.close();
-	return content;
 }
 
 void TestShell::exitApp() {

--- a/TestShell/TestShell_Test/TestShell_test.cpp
+++ b/TestShell/TestShell_Test/TestShell_test.cpp
@@ -12,7 +12,7 @@ using std::string;
 
 class SsdMock : public SsdApi {
 public:
-	MOCK_METHOD(int, read, (int lba), (override));
+	MOCK_METHOD(string, read, (int lba), (override));
 	MOCK_METHOD(void, write, (int lba, string data), (override));
 };
 
@@ -31,16 +31,6 @@ public:
 	SsdMock ssd;
 	TestShell* app = new TestShell(&ssd);
 };
-
-TEST_F(SsdTestShellFixture, WriteSuccess) {
-	// 수행 후 Read가 필요하나 아직 Read 구현 전이라 txt 열어서 결과 확인함.
-	app->write("3", "0xAAAABBBB");
-}
-
-TEST_F(SsdTestShellFixture, FullWriteSuccess) {
-	// 수행 후 Read가 필요하나 아직 Read 구현 전이라 txt 열어서 결과 확인함.
-	app->fullWrite("0xFFFFFFFF");
-}
 
 TEST_F(TestShellFixture, WriteSuccess) {
 	EXPECT_CALL(ssd, write(3, "0xAAAABBBB"))
@@ -91,6 +81,16 @@ TEST_F(TestShellFixture, fullReadSuccess) {
 			.Times(1);
 	}
 
+	app->fullRead();
+}
+
+TEST_F(SsdTestShellFixture, readwriteSuccess) {
+	app->write("3", "0xAAAABBBB");
+	app->read("3");
+}
+
+TEST_F(SsdTestShellFixture, fullReadWriteSuccess) {
+	app->fullWrite("0xFFFFFFFF");
 	app->fullRead();
 }
 


### PR DESCRIPTION
## 개요
TestShell 에서 SSD.exe 를 호출하여 read 할 수 있도록 Ssd class의 read기능을 구현했습니다.
readResultFile을 Ssd.cpp 위치로 옮기고 TestShell에 있던 read(), fullRead()를 수정하였습니다. 
TC를 @AhranChoi 님이 작업했던 부분과 합쳤습니다. 

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [x] 변경 사항에 대한 테스트를 했습니다.