### PR TITLE
[Add] TestShell erase, erase_range 기능 추가

### DIFF
--- a/TestShell/TestShell/Ssd.cpp
+++ b/TestShell/TestShell/Ssd.cpp
@@ -22,6 +22,11 @@ string Ssd::read(int lba)
 	return readResultFile("../../SSD/result.txt");
 }
 
+void Ssd::erase(int lba, int size) {
+	string eraseCmd = convertToEraseCmd(lba, size);
+	executeSsdCmd(eraseCmd);
+}
+
 string Ssd::readResultFile(const std::string& filepath) {
 	string content;
 	std::ifstream file(filepath);
@@ -44,6 +49,15 @@ string Ssd::convertToReadCmd(int lba)
 	string result = "R ";
 	result += std::to_string(lba);
 	result += " ";
+	return result;
+}
+
+string Ssd::convertToEraseCmd(int lba, int size)
+{
+	string result = "E ";
+	result += std::to_string(lba);
+	result += " ";
+	result += std::to_string(size);
 	return result;
 }
 

--- a/TestShell/TestShell/Ssd.h
+++ b/TestShell/TestShell/Ssd.h
@@ -4,6 +4,7 @@
 class Ssd : public SsdApi {
 public:
 	void write(int lba, std::string data) override;
+	void erase(int lba, int size) override;
 	std::string read(int lba) override;
 
 private:
@@ -11,6 +12,7 @@ private:
 
 	std::string convertToWriteCmd(int lba, std::string& data);
 	std::string convertToReadCmd(int lba);
+	std::string convertToEraseCmd(int lba, int size);
 	std::string readResultFile(const std::string& filepath);
 	void executeSsdCmd(std::string& cmdOption);
 };

--- a/TestShell/TestShell/SsdApi.h
+++ b/TestShell/TestShell/SsdApi.h
@@ -5,5 +5,6 @@
 
 interface SsdApi {
 	virtual void write(int lba, std::string data) = 0;
+	virtual void erase(int lba, int size) = 0;
 	virtual std::string read(int lba) = 0;
 };

--- a/TestShell/TestShell/TestShell.cpp
+++ b/TestShell/TestShell/TestShell.cpp
@@ -134,7 +134,7 @@ void TestShell::fullRead()
 void TestShell::erase(string startLba, string size)
 {
 	int iLba = verifyConvertLba(startLba);
-	int len = verifyConvertLba(size);
+	int len = verifyConvertLba_3(size);
 	if(iLba < 0 || iLba > 99) throw InvalidLbaException();
 	if(len < 1 || len > 100) throw InvalidLbaException();
 	divideEraseRange(iLba, len);
@@ -142,7 +142,7 @@ void TestShell::erase(string startLba, string size)
 
 void TestShell::divideEraseRange(int iLba, int len)
 {
-	if (iLba + len > 100) len = iLba + len - 100;
+	if (iLba + len > 100) len = 100 - iLba;
 	if (len <= 10) {
 		ssdApi->erase(iLba, len);
 		return;
@@ -162,9 +162,9 @@ void TestShell::divideEraseRange(int iLba, int len)
 void TestShell::erase_range(string startLba, string endLba)
 {
 	int startIdx = verifyConvertLba(startLba);
-	int endIdx = verifyConvertLba(endLba);
+	int endIdx = verifyConvertLba_3(endLba);
 	if (startIdx < 0 || startIdx > 99) throw InvalidLbaException();
-	if (endIdx < 0 || endIdx > 99) throw InvalidLbaException();
+	if (endIdx < 0 || endIdx > 100) throw InvalidLbaException();
 	
 	int len = endIdx - startIdx;
 	if(len < 1) throw InvalidLbaException();
@@ -175,6 +175,18 @@ void TestShell::erase_range(string startLba, string endLba)
 int TestShell::verifyConvertLba(string& strLba) {
 	int iLba = 0;
 	if (strLba.length() > 2) throw InvalidLbaException();
+
+	for (int i = 0; i < strLba.length(); i++) {
+		if (strLba[i] < '0' || strLba[i] > '9') throw InvalidLbaException();
+	}
+
+	iLba = stoi(strLba);
+	return iLba;
+}
+
+int TestShell::verifyConvertLba_3(string& strLba) {
+	int iLba = 0;
+	if (strLba.length() > 3) throw InvalidLbaException();
 
 	for (int i = 0; i < strLba.length(); i++) {
 		if (strLba[i] < '0' || strLba[i] > '9') throw InvalidLbaException();

--- a/TestShell/TestShell/TestShell.h
+++ b/TestShell/TestShell/TestShell.h
@@ -19,6 +19,8 @@ public:
 	void exitShell();
 	void help(string command);
 	void fullWrite(string input);
+	void erase(string startLba, string size);
+	void erase_range(string startLba, string endLba);
 
 private:
 	static TestShell* testShell;
@@ -29,8 +31,8 @@ private:
 	void verifyWriteDataLength(std::string& strData);
 	void verifyWriteDataHexNum(std::string& writeData);
 	int verifyConvertLba(std::string& strLba);
+	void divideEraseRange(int iLba, int len);
 
-	string readResultFile(const std::string& filepath);
 	void help_write();
 	void help_read();
 	void help_exit();

--- a/TestShell/TestShell/TestShell.h
+++ b/TestShell/TestShell/TestShell.h
@@ -31,6 +31,7 @@ private:
 	void verifyWriteDataLength(std::string& strData);
 	void verifyWriteDataHexNum(std::string& writeData);
 	int verifyConvertLba(std::string& strLba);
+	int verifyConvertLba_3(std::string& strLba);
 	void divideEraseRange(int iLba, int len);
 
 	void help_write();


### PR DESCRIPTION
## 개요
TestShell에 erase, erase_range 기능 추가하였습니다. 

1. erase startidx size
   만약 startidx랑 size가 0보다 작거나 99보다 크면 예외 처리 하였고, startidx + size 가 100을 초과 한 경우 그 차이 만큼 (startidx + size - 100)만 명령으로 들어가도록 하였습니다. 

2. erase_range startidx endidx
  마찬가지로 startidx랑 endidx가 0보다 작거나 99보다 크면 예외 처리 하였고, 두 인덱스의 차이 값(endidx - startidx)가 1과 100 범위 내에 없으면 예외처리 하였습니다. 

3. divideEraseRange 함수 생성
  size 값이 10 초과로 쪼개서 들어가야 할 경우 나눠서 명령이 들어가도록 하였습니다.
예시 erase 0 63의 경우
E 0 10, E 10 10, E 20 10, E 30 10, E 40 10, E 50 10, E 60 3이 되도록 나눠서 명령이 들어가도록 하였습니다. 

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [x] 변경 사항에 대한 테스트를 했습니다.