### PR TITLE
[fix] main에서 split 하지 않은 command를 구분하기 위한 코드 추가

### DIFF
--- a/TestShell/TestShell/Command/CommandFactory.cpp
+++ b/TestShell/TestShell/Command/CommandFactory.cpp
@@ -45,6 +45,9 @@ ICommand* CommandFactory::getCommand(vector<string>& commandAndOptions)
 
 bool CommandFactory::isSupportedCommand(std::string& command)
 {
+	int commandOff = command.find(' ');
+	if (commandOff != -1) command = command.substr(0, commandOff);
+
 	for (auto& curCommand : supportedCommands) {
 		if (command == curCommand) return true;
 	}


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
TestShell main에서 들어온 명령어 구분하는 코드를 CommandFactory에 통합했는데 parsing 에서 split 되지 않은 명령어를 구분하지 못하는 이슈가 있어 수정했습니다.

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [x] 변경 사항에 대한 테스트를 했습니다.