### PR TITLE
[Add] readSsd에 Buffer.txt 먼저 읽는 기능 추가

### DIFF
--- a/SSD/SSD/Ssd.cpp
+++ b/SSD/SSD/Ssd.cpp
@@ -36,12 +36,31 @@ string Ssd::readResult() {
 
 bool Ssd::checkBuffer(int LbAIndex) {
 	vector<string> bufferData = ssd_buffer.readBuffer();
+	bool flag = false;
+	string ans = "";
 	for (int i = 0; i < bufferData.size(); i++) {
-		string temp = bufferData[i];
+		string cmd = bufferData[i];
+		if (cmd.find("W") == 0) {
+			vector<string> args = splitString(cmd);
+			int LBA = stoi(args[1]);
+			string LBAData = args[2];
+			if (LBA == LbAIndex) {
+				ans = LBAData;
+				flag = true;
+			}
+		}
+		if (cmd.find("E") == 0) {
+			vector<string> args = splitString(cmd);
+			int startIdx = stoi(args[1]);
+			int endIdx = stoi(args[2]);
+			if (LbAIndex >= startIdx && LbAIndex < endIdx) {
+				ans = "0x00000000";
+				flag = true;
+			}
+		}
 	}
-	bool check = 1;
-	updateReadResult("0x" + nandData.substr(startIndex, 8));
-	return true;
+	updateReadResult(ans);
+	return flag;
 }
 
 void Ssd::readSsd(int LBAIndex) {

--- a/SSD/SSD_Test/Ssd_test.cpp
+++ b/SSD/SSD_Test/Ssd_test.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "../SSD/Ssd.cpp"
+#include "../SSD/Buffer.cpp"
 using namespace testing;
 
 class SsdVirtualFixture : public Test {


### PR DESCRIPTION
## 개요
SSD에서 read 명령 수행시 Buffer.txt를 먼저 읽고 찾으려는 인덱스가 있는 경우 이를 바로 넘기는 함수를 추가하였습니다. 
buffer.txt에 W와 E명령어 예제로 넣고 제대로 읽는지 테스트 하였습니다. 

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [x] 변경 사항에 대한 테스트를 했습니다.